### PR TITLE
Chrom fix

### DIFF
--- a/spliceai/utils.py
+++ b/spliceai/utils.py
@@ -87,7 +87,7 @@ def get_delta_scores(record, ann, L=1001):
             ref_len = len(record.ref)
             alt_len = len(record.alts[j])
             del_len = max(ref_len-alt_len, 0)
-            seq = ann.ref_fasta[str(record.chrom)][
+            seq = ann.ref_fasta[record.chrom][
                                 record.pos-W//2-1:record.pos+W//2]
             x_ref = 'N'*pad_size[0]+seq[pad_size[0]:W-pad_size[1]]\
                      +'N'*pad_size[1]

--- a/spliceai/utils.py
+++ b/spliceai/utils.py
@@ -87,8 +87,7 @@ def get_delta_scores(record, ann, L=1001):
             ref_len = len(record.ref)
             alt_len = len(record.alts[j])
             del_len = max(ref_len-alt_len, 0)
-
-            seq = ann.ref_fasta['chr'+str(record.chrom)][
+            seq = ann.ref_fasta[str(record.chrom)][
                                 record.pos-W//2-1:record.pos+W//2]
             x_ref = 'N'*pad_size[0]+seq[pad_size[0]:W-pad_size[1]]\
                      +'N'*pad_size[1]


### PR DESCRIPTION
Original code fails if user's VCF has chromosome names starting 'chr' or if their FASTA reference has chromosome names without the 'chr' prefix. More to the point, the original code fails if the input VCF has the same chromosome names as their reference FASTA (which should be the case in the vast majority of use cases).

This commit simply requires that the user uses the same FASTA reference that they used to generate their VCF file.