### PR TITLE
Fail better on reference genome load

### DIFF
--- a/spliceai/utils.py
+++ b/spliceai/utils.py
@@ -30,9 +30,9 @@ class Annotator:
             exit()
 
         try:
-            self.ref_fasta = Fasta(ref_fasta)
-        except IOError:
-            logging.error('Reference genome fasta file {} not found, exiting.'.format(ref_fasta))
+            self.ref_fasta = Fasta(ref_fasta, rebuild=False)
+        except IOError as e:
+            logging.error('Error reading reference genome file ({}): {}'.format(ref_fasta, e))
             exit()
 
         paths = ('models/spliceai{}.h5'.format(x) for x in range(1, 6))


### PR DESCRIPTION
As mentioned in #24 , if the filesystem or fasta index file are not writable SpliceAI will fail with an incorrect error message.

To fix this:
* setting `Fasta` to not rebuild the index if it already exists, which negates the problem in our case and seems a reasonable default
* Had logging output the actual error message, as the error message being printed may not be the correct one as in this case